### PR TITLE
doc/rados/operations/add-or-rm-mons.rst: Add chown to ceph user for mon directory.

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -135,7 +135,7 @@ on ``mon.a``).
    .. prompt:: bash $
 
       sudo ceph-mon -i {mon-id} --mkfs --monmap {tmp}/{map-filename} --keyring {tmp}/{key-filename}
-	
+      sudo chown -R ceph:ceph /var/lib/ceph/mon/ceph-{mon-id}
 
 #. Start the new monitor and it will automatically join the cluster.
    The daemon needs to know which address to bind to, via either the
@@ -144,7 +144,7 @@ on ``mon.a``).
    
    .. prompt:: bash $
 
-      ceph-mon -i {mon-id} --public-addr {ip:port}
+      ceph-mon -i {mon-id} --public-addr {ip:port} --setuser ceph --setgroup ceph
 
 .. _removing-monitors:
 


### PR DESCRIPTION
The actual user-id in this article is very vague. It starts with having you create "a user" that can ssh and sudo, then creates lots of stuff as root, then starts ceph-mon as .. some random uid which will not necessarily be able to read root-owned files, and is not certain to be "ceph" either.

While this manual perhaps gets you something that runs, you would probably be using systemctl or whatever upstart handler your OS comes with at step #6, and not have the mon hang off your login-as-some-user ssh session. At least systemd unit files will set user and group to "ceph" for the ceph-mon, so if you mkfs'd and ran ceph-mon as something else before, then this is when you will notice if perms are bad.





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [ ] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [ ] No impact that needs to be tracked
- Documentation (select at least one)
  - [ ] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [ ] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
