### PR TITLE
doc/rados/operations/add-or-rm-mons.rst: uid fixes

### DIFF
--- a/doc/rados/operations/add-or-rm-mons.rst
+++ b/doc/rados/operations/add-or-rm-mons.rst
@@ -135,7 +135,7 @@ on ``mon.a``).
    .. prompt:: bash $
 
       sudo ceph-mon -i {mon-id} --mkfs --monmap {tmp}/{map-filename} --keyring {tmp}/{key-filename}
-	
+      sudo chown -R ceph:ceph /var/lib/ceph/mon/ceph-{mon-id}
 
 #. Start the new monitor and it will automatically join the cluster.
    The daemon needs to know which address to bind to, via either the
@@ -144,7 +144,7 @@ on ``mon.a``).
    
    .. prompt:: bash $
 
-      ceph-mon -i {mon-id} --public-addr {ip:port}
+      sudo ceph-mon -i {mon-id} --public-addr {ip:port} --setuser ceph --setgroup ceph
 
 .. _removing-monitors:
 


### PR DESCRIPTION
The docs are vague on which user logs in and creates the content when a new mon is set up.

This diff makes the dir and newly made DB owned by ceph:ceph instead of root, and makes sure the first invocation of ceph-mon also sets user id to ceph:ceph instead of whatever you chose in the beginning of this page doc ("create a user that can ssh and run sudo"), so that is matches with the owner you get when your upstart handler (systemd) will set for running the ceph monitor.

Signed-off-by: Jan Johansson <icepic.dz@gmail.com>





<!--
  - Please give your pull request a title like

      [component]: [short description]

  - Please use this format for each git commit message:

      [component]: [short description]

      [A longer multiline description]

      Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
      Signed-off-by: [Your Name] <[your email]>

    For examples, use "git log".
-->

## Contribution Guidelines
- To sign and title your commits, please refer to [Submitting Patches to Ceph](https://github.com/ceph/ceph/blob/main/SubmittingPatches.rst).

- If you are submitting a fix for a stable branch (e.g. "pacific"), please refer to [Submitting Patches to Ceph - Backports](https://github.com/ceph/ceph/blob/master/SubmittingPatches-backports.rst) for the proper workflow.

## Checklist
- Tracker (select at least one)
  - [ ] References tracker ticket
  - [ ] Very recent bug; references commit where it was introduced
  - [ ] New feature (ticket optional)
  - [x] Doc update (no ticket needed)
  - [ ] Code cleanup (no ticket needed)
- Component impact
  - [ ] Affects [Dashboard](https://tracker.ceph.com/projects/dashboard/issues/new), opened tracker ticket
  - [ ] Affects [Orchestrator](https://tracker.ceph.com/projects/orchestrator/issues/new), opened tracker ticket
  - [x] No impact that needs to be tracked
- Documentation (select at least one)
  - [x] Updates relevant documentation
  - [ ] No doc update is appropriate
- Tests (select at least one)
  - [ ] Includes [unit test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/tests-unit-tests/)
  - [ ] Includes [integration test(s)](https://docs.ceph.com/en/latest/dev/developer_guide/testing_integration_tests/)
  - [ ] Includes bug reproducer
  - [x] No tests

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`
- `jenkins test windows`
</details>
